### PR TITLE
add mtime based cacher

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -453,7 +453,7 @@ module Puppet::Environments
     end
 
     class FileMtimeEntry < Entry
-      def initialize(env, path)
+      def initialize(value, path)
         super value
         @mtime   = Time.now
         @evicted = false


### PR DESCRIPTION
puppet is evicting environment all the time by default. our deployment of environments means that mtime of environment.conf is always updated when branch/code changes. this changes default caching behavior to stat environment.conf every 10 seconds and evict cache entries when mtime changes.

large catalog compilation time went down from 2 minutes to 1 minute.
