### PR TITLE
cache env conf same as env is cached

### DIFF
--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -342,6 +342,7 @@ module Puppet::Environments
       @loader = loader
       @cache = {}
       @cache_expiration_service = Puppet::Environments::Cached.cache_expiration_service
+      @cache_conf = {}
     end
 
     # @!macro loader_list
@@ -369,12 +370,14 @@ module Puppet::Environments
     # (The intention is that this could be used from a MANUAL cache eviction command (TBD)
     def clear(name)
       @cache.delete(name)
+      @cache_conf.delete(name)
     end
 
     # Clears all cached environments.
     # (The intention is that this could be used from a MANUAL cache eviction command (TBD)
     def clear_all()
       @cache = {}
+      @cache_conf = {}
     end
 
     # This implementation evicts the cache, and always gets the current
@@ -387,7 +390,7 @@ module Puppet::Environments
     # @!macro loader_get_conf
     def get_conf(name)
       evict_if_expired(name)
-      @loader.get_conf(name)
+      @cache_conf.fetch(name) { @cache_conf[name] = @loader.get_conf(name) }
     end
 
     # Creates a suitable cache entry given the time to live for one environment

--- a/lib/puppet/environments.rb
+++ b/lib/puppet/environments.rb
@@ -413,6 +413,7 @@ module Puppet::Environments
     def evict_if_expired(name)
       if (result = @cache[name]) && (result.expired? || @cache_expiration_service.expired?(name))
         @cache.delete(name)
+        @cache_conf.delete(name)
         @cache_expiration_service.evicted(name)
 
         Puppet.settings.clear_environment_settings(name)


### PR DESCRIPTION
use the same cacher class and logic to cache env configs. currently they are always evicted and reloaded which is a big performance hit. `future_parser?` is one example where env config get reloaded.

this pr makes use of same caching logic as env itself, so they are evicted together.
