### PR TITLE
Use systemd by default on bionic (18.04) and above

### DIFF
--- a/lib/puppet/provider/service/systemd.rb
+++ b/lib/puppet/provider/service/systemd.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:service).provide :systemd, :parent => :base do
   defaultfor :osfamily => :redhat, :operatingsystem => :fedora, :operatingsystemmajrelease => ["17", "18", "19", "20", "21"]
   defaultfor :osfamily => :suse, :operatingsystemmajrelease => ["12", "13"]
   defaultfor :operatingsystem => :debian, :operatingsystemmajrelease => "8"
-  defaultfor :operatingsystem => :ubuntu, :operatingsystemmajrelease => ["15.04","15.10","16.04"]
+  defaultfor :operatingsystem => :ubuntu
 
   def self.instances
     i = []

--- a/spec/unit/provider/service/systemd_spec.rb
+++ b/spec/unit/provider/service/systemd_spec.rb
@@ -119,6 +119,13 @@ describe Puppet::Type.type(:service).provider(:systemd) do
     expect(described_class).to be_default
   end
 
+  it "should be the default provider on ubuntu18.04" do
+    Facter.stubs(:value).with(:osfamily).returns(:debian)
+    Facter.stubs(:value).with(:operatingsystem).returns(:ubuntu)
+    Facter.stubs(:value).with(:operatingsystemmajrelease).returns("18.04")
+    expect(described_class).to be_default
+  end
+
   [:enabled?, :enable, :disable, :start, :stop, :status, :restart].each do |method|
     it "should have a #{method} method" do
       expect(provider).to respond_to(method)


### PR DESCRIPTION
This was [changed upstream](https://github.com/puppetlabs/puppet/blob/114fbf11ca2b4d401c33f16541d48836f01313ed/lib/puppet/provider/service/systemd.rb#L31-L32) to make this the default for all ubuntu but not the default for trusty and below.

We don't have `notdefaultfor` in our current version, but this at least brings us closer to that behavior by supporting bionic.

As a workaround, I've just added `provider => 'systemd'` to some services to get them working for bionic and check that the provider was indeed the problem, but this is a more widespread change.